### PR TITLE
feat: add dashboard and supabase-powered components

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Available UI Components
+
+- **Dashboard**: halaman dasar dengan judul "Dashboard Madrasah Digital" dan tombol "Mulai Absensi". Dapat diakses di `/dashboard`.
+- **Absensi**: menampilkan daftar siswa dari Supabase. Dapat diakses di `/absensi`.
+- **Daftar Siswa**: daftar sederhana seluruh siswa, tersedia di `/students`.
+- **Login**: form autentikasi menggunakan Supabase auth pada `/login`.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/f042acfa-48ad-4d13-b7b7-90c40dcd7a1e) and click on Share -> Publish.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Dashboard from "@/components/Dashboard";
+import Absensi from "@/components/Absensi";
+import DaftarSiswa from "@/components/DaftarSiswa";
+import Login from "@/components/Login";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +20,10 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/absensi" element={<Absensi />} />
+          <Route path="/students" element={<DaftarSiswa />} />
+          <Route path="/login" element={<Login />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Absensi.tsx
+++ b/src/components/Absensi.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { fetchStudents } from "@/integrations/supabase/students";
+
+interface Student {
+  id: number;
+  name: string;
+}
+
+const Absensi = () => {
+  const [students, setStudents] = useState<Student[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchStudents()
+      .then((data) => setStudents(data as Student[]))
+      .catch((err) => setError(err.message));
+  }, []);
+
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-semibold mb-4">Absensi</h2>
+      {error && <p className="text-red-500">{error}</p>}
+      <ul className="space-y-2">
+        {students.map((student) => (
+          <li key={student.id} className="border p-2 rounded">
+            {student.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Absensi;

--- a/src/components/DaftarSiswa.tsx
+++ b/src/components/DaftarSiswa.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { fetchStudents } from "@/integrations/supabase/students";
+
+interface Student {
+  id: number;
+  name: string;
+}
+
+const DaftarSiswa = () => {
+  const [students, setStudents] = useState<Student[]>([]);
+
+  useEffect(() => {
+    fetchStudents().then((data) => setStudents(data as Student[]));
+  }, []);
+
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-semibold mb-4">Daftar Siswa</h2>
+      <ul className="list-disc pl-5 space-y-1">
+        {students.map((student) => (
+          <li key={student.id}>{student.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DaftarSiswa;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const Dashboard = () => {
+  return (
+    <div className="p-6">
+      <h1 className="text-3xl font-bold mb-4">Dashboard Madrasah Digital</h1>
+      <button className="px-4 py-2 bg-blue-600 text-white rounded">Mulai Absensi</button>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+
+const Login = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    setMessage(error ? error.message : "Login berhasil");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-sm p-6 space-y-4">
+      <h2 className="text-2xl font-semibold">Login</h2>
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        className="w-full border p-2"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+        className="w-full border p-2"
+      />
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+        Masuk
+      </button>
+      {message && <p className="text-sm text-gray-600">{message}</p>}
+    </form>
+  );
+};
+
+export default Login;

--- a/src/integrations/supabase/students.ts
+++ b/src/integrations/supabase/students.ts
@@ -1,0 +1,9 @@
+import { supabase } from "./client";
+
+export const fetchStudents = async () => {
+  const { data, error } = await supabase.from("students").select("*");
+  if (error) {
+    throw error;
+  }
+  return data;
+};


### PR DESCRIPTION
## Summary
- add dashboard with Tailwind styling
- create Absensi, DaftarSiswa, and Login components pulling data/auth from Supabase
- expose dashboard and feature routes in App and document them in README

## Testing
- `npm run lint` (fails: An interface declaring no members is equivalent to its supertype)
- `npm test` (fails: Missing script: "test")
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6899ded91c6c832b9b4bcc3620142ca6