### PR TITLE
Add role-based auth, monitoring, and backup plan

### DIFF
--- a/BACKUP_PLAN.md
+++ b/BACKUP_PLAN.md
@@ -1,0 +1,17 @@
+# Rencana Backup dan Recovery Data
+
+Project ini menggunakan Supabase sebagai basis data. Berikut rencana backup dan pemulihan data:
+
+## Backup
+- Gunakan fitur [PITR (Point-in-time Recovery)](https://supabase.com/docs/guides/platform/backups) atau jadwal backup harian dari Supabase.
+- Simpan salinan cadangan ke lokasi terpisah (mis. storage eksternal atau bucket S3) untuk redundansi.
+- Lakukan backup manual sebelum melakukan migrasi skema besar.
+
+## Recovery
+- Uji proses restore secara berkala pada lingkungan pengujian untuk memastikan cadangan valid.
+- Dokumentasikan langkah pemulihan sehingga tim dapat melakukan restore dengan cepat saat terjadi kegagalan.
+- Gunakan cadangan terbaru dan, bila diperlukan, manfaatkan PITR untuk memulihkan hingga waktu tertentu.
+
+## Monitoring
+- Pantau proses backup dan kirim notifikasi bila backup gagal.
+- Catat waktu dan lokasi setiap backup untuk audit.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,65 @@
+import ErrorBoundary from "@/components/ErrorBoundary";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import ProtectedRoute from "@/components/ProtectedRoute";
+import { AuthProvider } from "@/lib/auth";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Login from "./pages/Login";
+import AdminDashboard from "./pages/AdminDashboard";
+import TeacherDashboard from "./pages/TeacherDashboard";
+import StudentDashboard from "./pages/StudentDashboard";
+import Unauthorized from "./pages/Unauthorized";
 
 const queryClient = new QueryClient();
 
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+  <ErrorBoundary>
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <AuthProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<Index />} />
+              <Route path="/login" element={<Login />} />
+              <Route
+                path="/admin"
+                element={
+                  <ProtectedRoute roles={["admin"]}>
+                    <AdminDashboard />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/guru"
+                element={
+                  <ProtectedRoute roles={["guru"]}>
+                    <TeacherDashboard />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/siswa"
+                element={
+                  <ProtectedRoute roles={["siswa"]}>
+                    <StudentDashboard />
+                  </ProtectedRoute>
+                }
+              />
+              <Route path="/unauthorized" element={<Unauthorized />} />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </BrowserRouter>
+        </AuthProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  </ErrorBoundary>
 );
 
 export default App;

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { logError } from "@/lib/monitoring";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    void logError(`${error.message} - ${info.componentStack}`);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p>Terjadi kesalahan.</p>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,24 @@
+import { type ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "@/lib/auth";
+
+interface Props {
+  children: ReactNode;
+  roles?: string[];
+}
+
+const ProtectedRoute = ({ children, roles }: Props) => {
+  const { user, role } = useAuth();
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (roles && role && !roles.includes(role)) {
+    return <Navigate to="/unauthorized" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import type { Session, User } from "@supabase/supabase-js";
+import { supabase } from "@/integrations/supabase/client";
+
+interface AuthContextValue {
+  user: User | null;
+  role: string | null;
+}
+
+const AuthContext = createContext<AuthContextValue>({ user: null, role: null });
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [role, setRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    const setSession = (session: Session | null) => {
+      const u = session?.user ?? null;
+      setUser(u);
+      setRole(u?.user_metadata?.role ?? null);
+    };
+
+    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  return <AuthContext.Provider value={{ user, role }}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => useContext(AuthContext);
+
+export const signIn = (email: string, password: string) =>
+  supabase.auth.signInWithPassword({ email, password });
+
+export const signOut = () => supabase.auth.signOut();

--- a/src/lib/monitoring.ts
+++ b/src/lib/monitoring.ts
@@ -1,0 +1,32 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export const logError = async (error: unknown) => {
+  console.error(error);
+  try {
+    await supabase.from("error_logs").insert({ message: String(error) });
+  } catch (e) {
+    console.error("Failed to store error log", e);
+  }
+};
+
+export const logPerformance = async () => {
+  const perf = performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming;
+  const metrics = {
+    domContentLoaded: perf.domContentLoadedEventEnd - perf.startTime,
+    loadEvent: perf.loadEventEnd - perf.startTime,
+  };
+  console.log("Performance metrics", metrics);
+  try {
+    await supabase.from("performance_logs").insert(metrics);
+  } catch (e) {
+    console.error("Failed to store performance log", e);
+  }
+};
+
+export const initMonitoring = () => {
+  window.addEventListener("error", (event) => logError(event.error));
+  window.addEventListener("unhandledrejection", (event) => logError(event.reason));
+  window.addEventListener("load", () => {
+    void logPerformance();
+  });
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,8 @@
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import { initMonitoring } from './lib/monitoring';
 
-createRoot(document.getElementById("root")!).render(<App />);
+initMonitoring();
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,0 +1,15 @@
+import { Button } from "@/components/ui/button";
+import { useAuth, signOut } from "@/lib/auth";
+
+const AdminDashboard = () => {
+  const { user } = useAuth();
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Admin Dashboard</h1>
+      <p>Welcome, {user?.email}</p>
+      <Button onClick={() => void signOut()}>Keluar</Button>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,59 @@
+import { useState, type FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import { signIn } from "@/lib/auth";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+
+const Login = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const { data, error } = await signIn(email, password);
+    if (error) {
+      setError(error.message);
+      return;
+    }
+    const role = data.user.user_metadata?.role;
+    if (role === "admin") navigate("/admin");
+    else if (role === "guru") navigate("/guru");
+    else navigate("/siswa");
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <Button type="submit" className="w-full">
+          Masuk
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/pages/StudentDashboard.tsx
+++ b/src/pages/StudentDashboard.tsx
@@ -1,0 +1,15 @@
+import { Button } from "@/components/ui/button";
+import { useAuth, signOut } from "@/lib/auth";
+
+const StudentDashboard = () => {
+  const { user } = useAuth();
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Siswa Dashboard</h1>
+      <p>Welcome, {user?.email}</p>
+      <Button onClick={() => void signOut()}>Keluar</Button>
+    </div>
+  );
+};
+
+export default StudentDashboard;

--- a/src/pages/TeacherDashboard.tsx
+++ b/src/pages/TeacherDashboard.tsx
@@ -1,0 +1,15 @@
+import { Button } from "@/components/ui/button";
+import { useAuth, signOut } from "@/lib/auth";
+
+const TeacherDashboard = () => {
+  const { user } = useAuth();
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Guru Dashboard</h1>
+      <p>Welcome, {user?.email}</p>
+      <Button onClick={() => void signOut()}>Keluar</Button>
+    </div>
+  );
+};
+
+export default TeacherDashboard;

--- a/src/pages/Unauthorized.tsx
+++ b/src/pages/Unauthorized.tsx
@@ -1,0 +1,8 @@
+const Unauthorized = () => (
+  <div className="p-4">
+    <h1 className="text-2xl mb-4">Tidak memiliki akses</h1>
+    <p>Silakan masuk dengan akun yang sesuai.</p>
+  </div>
+);
+
+export default Unauthorized;


### PR DESCRIPTION
## Summary
- implement Supabase-based auth context with role-aware protected routes and dashboards
- add basic performance/error monitoring module and React error boundary
- document data backup and recovery strategy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in UI components and config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899f23f3c20832b8fff64060c28ef45