### PR TITLE
feat: add authenticated dashboard layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Login from "./pages/Login";
+import Dashboard from "./pages/Dashboard";
+import ProtectedRoute from "./components/ProtectedRoute";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +19,15 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/login" element={<Login />} />
+          <Route
+            path="/dashboard/*"
+            element={
+              <ProtectedRoute>
+                <Dashboard />
+              </ProtectedRoute>
+            }
+          />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+}
+
+const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+  const token = localStorage.getItem("token");
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/src/components/dashboard/Navbar.tsx
+++ b/src/components/dashboard/Navbar.tsx
@@ -1,0 +1,31 @@
+import { NavLink } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+interface NavbarProps {
+  onLogout: () => void;
+  onToggleMenu: () => void;
+  role: string;
+  email?: string;
+}
+
+const Navbar = ({ onLogout, onToggleMenu, role, email }: NavbarProps) => {
+  return (
+    <nav className="flex items-center justify-between border-b p-4">
+      <Button variant="outline" className="md:hidden" onClick={onToggleMenu}>
+        Menu
+      </Button>
+      <div className="flex-1" />
+      <div className="flex items-center space-x-4">
+        <NavLink to="/" className="text-sm">
+          Home
+        </NavLink>
+        <span className="text-sm capitalize">{email || role}</span>
+        <Button variant="ghost" onClick={onLogout}>
+          Logout
+        </Button>
+      </div>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/src/components/dashboard/Sidebar.tsx
+++ b/src/components/dashboard/Sidebar.tsx
@@ -1,0 +1,23 @@
+import { NavLink } from "react-router-dom";
+
+interface SidebarProps {
+  items: { name: string; path: string }[];
+}
+
+const Sidebar = ({ items }: SidebarProps) => {
+  return (
+    <aside className="w-64 bg-gray-800 p-4 text-white space-y-2">
+      {items.map((item) => (
+        <NavLink
+          key={item.path}
+          to={item.path}
+          className="block rounded p-2 hover:bg-gray-700"
+        >
+          {item.name}
+        </NavLink>
+      ))}
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Sidebar from "@/components/dashboard/Sidebar";
+import Navbar from "@/components/dashboard/Navbar";
+import { supabase } from "@/integrations/supabase/client";
+
+const Dashboard = () => {
+  const navigate = useNavigate();
+  const role = localStorage.getItem("role") || "siswa";
+  const [showSidebar, setShowSidebar] = useState(false);
+  const [email, setEmail] = useState("");
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      if (data.user?.email) {
+        setEmail(data.user.email);
+      }
+    });
+  }, []);
+
+  const menus: Record<string, { name: string; path: string }[]> = {
+    admin: [
+      { name: "Dashboard", path: "/dashboard" },
+      { name: "Manage Users", path: "/dashboard/users" },
+    ],
+    guru: [
+      { name: "Dashboard", path: "/dashboard" },
+      { name: "My Classes", path: "/dashboard/classes" },
+    ],
+    siswa: [
+      { name: "Dashboard", path: "/dashboard" },
+      { name: "My Courses", path: "/dashboard/courses" },
+    ],
+    wali: [
+      { name: "Dashboard", path: "/dashboard" },
+      { name: "Reports", path: "/dashboard/reports" },
+    ],
+  };
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    localStorage.removeItem("token");
+    localStorage.removeItem("role");
+    navigate("/");
+  };
+
+  return (
+    <div className="flex min-h-screen">
+      <div className={`${showSidebar ? "block" : "hidden md:block"}`}>
+        <Sidebar items={menus[role] || []} />
+      </div>
+      <div className="flex flex-1 flex-col">
+        <Navbar
+          onLogout={handleLogout}
+          onToggleMenu={() => setShowSidebar(!showSidebar)}
+          role={role}
+          email={email}
+        />
+        <main className="flex-1 p-4">
+          <h1 className="text-2xl font-bold">Welcome to Dashboard</h1>
+          <p>Your role: {role}</p>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/integrations/supabase/client";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const Login = () => {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) {
+      setError(error.message);
+      return;
+    }
+    if (data.session) {
+      localStorage.setItem("token", data.session.access_token);
+      const role = data.user?.user_metadata?.role;
+      if (role) {
+        localStorage.setItem("role", role);
+      }
+      navigate("/dashboard");
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <Input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <Button type="submit" className="w-full">
+          Login
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default Login;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -100,5 +101,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add login page that authenticates with Supabase and stores session token
- introduce responsive dashboard layout with role-based sidebar and navbar
- protect dashboard route and add logout that clears stored session

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ab66e39a8832ba007e3c4ce360821