### PR TITLE
Add role table for Admin, Guru, Siswa, and Orang Tua

### DIFF
--- a/src/components/RoleTable.tsx
+++ b/src/components/RoleTable.tsx
@@ -1,0 +1,43 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+
+const roles = [
+  { name: "Admin", description: "Mengelola seluruh sistem dan pengguna" },
+  { name: "Guru", description: "Mengelola materi dan nilai siswa" },
+  { name: "Siswa", description: "Akses materi dan mengikuti pembelajaran" },
+  { name: "Orang Tua", description: "Memantau perkembangan dan nilai siswa" }
+];
+
+const RoleTable = () => {
+  return (
+    <section className="py-20 bg-muted/30">
+      <div className="container mx-auto px-4">
+        <h2 className="text-3xl font-bold text-primary mb-8 text-center">Daftar Role</h2>
+        <div className="rounded-md border shadow-sm overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow className="bg-primary text-primary-foreground">
+                <TableHead className="w-1/3">Role</TableHead>
+                <TableHead>Deskripsi</TableHead>
+                <TableHead className="text-right">Aksi</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {roles.map((role) => (
+                <TableRow key={role.name}>
+                  <TableCell className="font-medium">{role.name}</TableCell>
+                  <TableCell>{role.description}</TableCell>
+                  <TableCell className="text-right">
+                    <Button variant="outline" size="sm">Detail</Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default RoleTable;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import Features from "@/components/Features";
+import RoleTable from "@/components/RoleTable";
 import Footer from "@/components/Footer";
 
 const Index = () => {
@@ -9,6 +10,7 @@ const Index = () => {
       <Header />
       <Hero />
       <Features />
+      <RoleTable />
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- add RoleTable component for Admin, Guru, Siswa, Orang Tua with consistent colors and clear action buttons
- display RoleTable on index page for an easy layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b41018410832b97731939e61aa56a