### PR TITLE
feat: add payments and invoices support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Payments from "./pages/Payments";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/payments" element={<Payments />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -12,24 +12,76 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: "13.0.4"
   }
-  public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      [_ in never]: never
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
+    public: {
+      Tables: {
+        invoices: {
+          Row: {
+            id: string
+            total: number
+            status: string | null
+            created_at: string | null
+          }
+          Insert: {
+            id?: string
+            total: number
+            status?: string | null
+            created_at?: string | null
+          }
+          Update: {
+            id?: string
+            total?: number
+            status?: string | null
+            created_at?: string | null
+          }
+          Relationships: []
+        }
+        payments: {
+          Row: {
+            id: string
+            invoice_id: string | null
+            amount: number
+            status: string | null
+            created_at: string | null
+          }
+          Insert: {
+            id?: string
+            invoice_id?: string | null
+            amount: number
+            status?: string | null
+            created_at?: string | null
+          }
+          Update: {
+            id?: string
+            invoice_id?: string | null
+            amount?: number
+            status?: string | null
+            created_at?: string | null
+          }
+          Relationships: [
+            {
+              foreignKeyName: "payments_invoice_id_fkey"
+              columns: ["invoice_id"]
+              referencedRelation: "invoices"
+              referencedColumns: ["id"]
+            }
+          ]
+        }
+        [_ in never]: never
+      }
+      Views: {
+        [_ in never]: never
+      }
+      Functions: {
+        [_ in never]: never
+      }
+      Enums: {
+        [_ in never]: never
+      }
+      CompositeTypes: {
+        [_ in never]: never
+      }
     }
   }
-}
 
 type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 

--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -1,0 +1,40 @@
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "@/hooks/use-toast";
+import type { Tables } from "@/integrations/supabase/types";
+
+export type Payment = Tables<'payments'>;
+
+// Placeholder payment gateway integration
+export async function processPayment(invoiceId: string, amount: number) {
+  // simulate external gateway processing
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  const { data, error } = await supabase
+    .from('payments')
+    .insert({ invoice_id: invoiceId, amount, status: 'completed' })
+    .select()
+    .single();
+
+  if (error) {
+    toast({ title: 'Payment failed', description: error.message });
+    throw error;
+  }
+
+  toast({ title: 'Payment successful', description: `Invoice ${invoiceId} paid.` });
+
+  return data as Payment;
+}
+
+export async function getPaymentHistory() {
+  const { data, error } = await supabase
+    .from('payments')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    toast({ title: 'Failed to load payments', description: error.message });
+    throw error;
+  }
+
+  return data as Payment[];
+}

--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import { getPaymentHistory, processPayment, type Payment } from "@/lib/payments";
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+const Payments = () => {
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadPayments = async () => {
+    setLoading(true);
+    try {
+      const data = await getPaymentHistory();
+      setPayments(data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadPayments();
+  }, []);
+
+  const handleSimulate = async () => {
+    await processPayment("demo-invoice", 10000);
+    await loadPayments();
+  };
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold">Payment History</h1>
+        <Button onClick={handleSimulate}>Simulate Payment</Button>
+      </div>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Invoice</TableHead>
+              <TableHead>Amount</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Date</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {payments.map((p) => (
+              <TableRow key={p.id}>
+                <TableCell>{p.invoice_id}</TableCell>
+                <TableCell>{p.amount}</TableCell>
+                <TableCell>{p.status}</TableCell>
+                <TableCell>{new Date(p.created_at).toLocaleString()}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+};
+
+export default Payments;

--- a/supabase/migrations/20241107000000_create_payments_and_invoices.sql
+++ b/supabase/migrations/20241107000000_create_payments_and_invoices.sql
@@ -1,0 +1,14 @@
+create table if not exists invoices (
+  id uuid primary key default gen_random_uuid(),
+  total numeric not null,
+  status text default 'unpaid',
+  created_at timestamptz default now()
+);
+
+create table if not exists payments (
+  id uuid primary key default gen_random_uuid(),
+  invoice_id uuid references invoices(id) on delete set null,
+  amount numeric not null,
+  status text default 'pending',
+  created_at timestamptz default now()
+);


### PR DESCRIPTION
## Summary
- add Supabase migrations for `payments` and `invoices`
- integrate placeholder payment gateway and toast notifications
- add payments page with transaction history

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, A `require()` style import is forbidden)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b44df781c832b8601564480e74906