### PR TITLE
chore: install build globally in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           node-version: 18
 
+      - name: Install build globally
+        run: npm install -g build
+
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+      - name: Install build globally
+        run: npm install -g build
       - run: npm install
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
## Summary
- install `build` globally during CI workflows

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint reported 3 errors and 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689b52e24484832b87ccf50924b9dd4a