### PR TITLE
Use Link for NotFound home link

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -16,9 +16,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace anchor tag with react-router-dom Link on NotFound page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, etc.)*
- `npx eslint src/pages/NotFound.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689daaaa7cb0832b845e873c4f60349e